### PR TITLE
Fix handshake peer identification

### DIFF
--- a/src/cypherpunks.ru/govpn/handshake.go
+++ b/src/cypherpunks.ru/govpn/handshake.go
@@ -141,8 +141,8 @@ func idTag(id *PeerId, timeSync int, data []byte) []byte {
 		panic(err)
 	}
 	mac.Write(enc)
-	mac.Sum(enc[:0])
-	return enc
+	sum := mac.Sum(nil)
+	return sum[len(sum)-8:]
 }
 
 // Start handshake's procedure from the client. It is the entry point

--- a/src/cypherpunks.ru/govpn/identity.go
+++ b/src/cypherpunks.ru/govpn/identity.go
@@ -113,9 +113,9 @@ func (mc *MACCache) Find(data []byte) *PeerId {
 		mt.l.Lock()
 		mt.mac.Reset()
 		mt.mac.Write(buf)
-		mt.mac.Sum(buf[:0])
+		sum := mt.mac.Sum(nil)
 		mt.l.Unlock()
-		if subtle.ConstantTimeCompare(buf, data[len(data)-8:]) == 1 {
+		if subtle.ConstantTimeCompare(sum[len(sum)-8:], data[len(data)-8:]) == 1 {
 			ppid := PeerId(pid)
 			mc.l.RUnlock()
 			return &ppid

--- a/src/cypherpunks.ru/govpn/peer.go
+++ b/src/cypherpunks.ru/govpn/peer.go
@@ -56,13 +56,17 @@ func newNonces(key *[32]byte, i uint64) chan *[NonceSize]byte {
 	if err != nil {
 		panic(err)
 	}
+	sum := make([]byte, mac.Size())
 	nonces := make(chan *[NonceSize]byte, NonceBucketSize*3)
 	go func() {
 		for {
 			buf := new([NonceSize]byte)
 			binary.BigEndian.PutUint64(buf[:], i)
 			mac.Write(buf[:])
-			mac.Sum(buf[:0])
+			sum = mac.Sum(nil)
+			for index := 0; index < NonceSize; index++ {
+				buf[index] = sum[index]
+			}
 			nonces <- buf
 			mac.Reset()
 			i += 2


### PR DESCRIPTION
Server couldn't validate peer ID, `MACCache.Find` always considered the first peer in cache to be the good one.